### PR TITLE
GH-33 Allows package to build for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ String cameraScanResult = await scanner.scan();
 ## Features
 
 -  Generate BR-CODE
--  Support IOS
+
+## TODO
+
+-  [] Support IOS (example builds, but invoking scanner does not return)
+-  [] Provide iOS setup documentation, if necessary
 
 ## Demo App
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,12 +16,12 @@ dependencies:
   image_gallery_saver: ^1.1.0
   image_picker: ^0.6.1+4
 
+  qrscan:
+    path: ../
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  qrscan:
-    path: ../
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: qrscan_example
 description: Demonstrates how to use the qrscan plugin.
 publish_to: 'none'
+version: 0.2.17
 
 environment:
   sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
This does not solve the entire problem for #33, but is a good first step. Specifically, it allows example to build for iOS.

Known issues:
* iOS simulator does not open QR scan process