### PR TITLE
Always throws the error when the analyze fails

### DIFF
--- a/android/src/main/java/com/shinow/qrscan/CustomAnalyzeCallback.java
+++ b/android/src/main/java/com/shinow/qrscan/CustomAnalyzeCallback.java
@@ -22,8 +22,6 @@ public class CustomAnalyzeCallback implements CodeUtils.AnalyzeCallback {
     @Override
     public void onAnalyzeFailed() {
         String errorCode = this.intent.getStringExtra("ERROR_CODE");
-        if (errorCode != null) {
-            this.result.error(errorCode, null, null);
-        }
+        this.result.error(errorCode, null, null);
     }
 }


### PR DESCRIPTION
**Error**
com.google.zxing.NotFoundException

**Platform**
Android

**Flutter**
1.22.5

**Dart**
2.10.4

The method `scanBytes` works fine with images that have some QR Code to analyze, but if you scan something without any QR Code the plugin doesn't returns the error. Using Visual Studio Code, I can see on Debug Console the message `W/System.err(27635): com.google.zxing.NotFoundException`. Unfortunatelly, the error can't be catched inside a `try/catch` block or `catchError` of the Future.

The current solution is return all errors catched by `onAnalyzeFailed` even if `errorCode` was equals to null, because the method `onAnalyzeFailed` is called when any error occurs.